### PR TITLE
responsive navigation header and side drawer

### DIFF
--- a/src/layout/appHeader.tsx
+++ b/src/layout/appHeader.tsx
@@ -1,34 +1,159 @@
-import React, {FC} from 'react'
-import {Link} from 'react-router-dom'
-import {AppBar, Toolbar, Typography, Button} from '@material-ui/core'
+import React, {FC, Dispatch, SetStateAction} from 'react'
+import {useHistory} from 'react-router-dom'
+import {
+  AppBar,
+  Toolbar,
+  Typography,
+  Button,
+  makeStyles,
+  IconButton,
+  Menu,
+  MenuItem,
+  useMediaQuery,
+  useTheme,
+  Divider,
+  ListSubheader,
+} from '@material-ui/core'
+import {AccountCircle} from '@material-ui/icons'
+import MenuIcon from '@material-ui/icons/Menu'
 import {useAuth0} from '@auth0/auth0-react'
+import {routes} from '../routes'
 
-export const AppHeader: FC = props => {
-  const {isAuthenticated, loginWithPopup, logout} = useAuth0()
+interface Props {
+  sideDrawOpen: boolean
+  setSideDrawerOpen: Dispatch<SetStateAction<boolean>>
+}
+
+/**
+ * Opening the user menu and side drawer generates a warning in the console
+ * Apparently this is a known issue when running material ui in strict mode https://github.com/mui-org/material-ui/issues/13394
+ * From my reading this will not happen in production and can be resolved by removing strict mode
+ */
+
+export const AppHeader: FC<Props> = ({sideDrawOpen, setSideDrawerOpen}) => {
+  const {isAuthenticated, loginWithPopup, logout, user} = useAuth0()
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
+  const userMenuOpen = Boolean(anchorEl)
+  const theme = useTheme()
+  const history = useHistory()
+  const isMobile = useMediaQuery(theme.breakpoints.down('xs'))
+
+  const useStyles = makeStyles(theme => ({
+    root: {
+      flexGrow: 1,
+    },
+    loginButton: {
+      marginLeft: theme.spacing(1),
+    },
+    menuButton: {
+      marginLeft: theme.spacing(1),
+    },
+    title: {
+      flexGrow: 1,
+    },
+    navLink: {
+      padding: theme.spacing(1),
+    },
+  }))
+  const classes = useStyles()
+
+  const handleMenu = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const handleClose = () => {
+    setAnchorEl(null)
+  }
+
+  const handleNavigate = (pageURL: string) => {
+    history.push(pageURL)
+  }
 
   return (
-    <>
+    <div className={classes.root}>
       <AppBar position="static">
         <Toolbar>
-          <Typography variant="h6">Prolly</Typography>
-          {!isAuthenticated ? (
-            <Button color="inherit" onClick={loginWithPopup}>
-              Login
-            </Button>
-          ) : (
-            <Link to={'/'}></Link>
-          )}
+          <Typography variant="h6" className={classes.title}>
+            Prolly
+          </Typography>
+
+          {!isMobile &&
+            routes
+              .filter(route => route.showInHeader)
+              .map(route => {
+                const {linkText, path} = route
+                return (
+                  <Button
+                    key={linkText}
+                    color="inherit"
+                    className={classes.navLink}
+                    onClick={() => handleNavigate(path)}
+                  >
+                    {linkText}
+                  </Button>
+                )
+              })}
+
           {isAuthenticated ? (
+            <div>
+              <IconButton
+                aria-label="account of current user"
+                aria-controls="menu-appbar"
+                aria-haspopup="true"
+                onClick={handleMenu}
+                color="inherit"
+              >
+                <AccountCircle />
+              </IconButton>
+              <Menu
+                id="menu-appbar"
+                anchorEl={anchorEl}
+                anchorOrigin={{
+                  vertical: 'top',
+                  horizontal: 'right',
+                }}
+                keepMounted
+                transformOrigin={{
+                  vertical: 'top',
+                  horizontal: 'right',
+                }}
+                open={userMenuOpen}
+                onClose={handleClose}
+              >
+                <ListSubheader>{user.nickname}</ListSubheader>
+                <Divider />
+                <MenuItem onClick={handleClose}>My account</MenuItem>
+                <MenuItem
+                  onClick={() => logout({returnTo: window.location.origin})}
+                >
+                  Log out
+                </MenuItem>
+              </Menu>
+            </div>
+          ) : (
             <Button
               color="inherit"
-              onClick={() => logout({returnTo: window.location.origin})}
+              onClick={loginWithPopup}
+              className={classes.loginButton}
             >
-              Logout
+              Login
             </Button>
+          )}
+          {isMobile ? (
+            <IconButton
+              edge="start"
+              className={classes.menuButton}
+              color="inherit"
+              aria-label="menu"
+              onClick={() => {
+                setSideDrawerOpen(!sideDrawOpen)
+              }}
+            >
+              <MenuIcon />
+            </IconButton>
           ) : null}
         </Toolbar>
       </AppBar>
-      {props.children}
-    </>
+    </div>
   )
 }

--- a/src/layout/appHeader.tsx
+++ b/src/layout/appHeader.tsx
@@ -20,8 +20,8 @@ import {useAuth0} from '@auth0/auth0-react'
 import {routes} from '../routes'
 
 interface Props {
-  sideDrawOpen: boolean
-  setSideDrawerOpen: Dispatch<SetStateAction<boolean>>
+  isSideDrawerOpen: boolean
+  setIsSideDrawerOpen: Dispatch<SetStateAction<boolean>>
 }
 
 /**
@@ -30,10 +30,16 @@ interface Props {
  * From my reading this will not happen in production and can be resolved by removing strict mode
  */
 
-export const AppHeader: FC<Props> = ({sideDrawOpen, setSideDrawerOpen}) => {
+export const AppHeader: FC<Props> = ({
+  isSideDrawerOpen,
+  setIsSideDrawerOpen,
+}) => {
   const {isAuthenticated, loginWithPopup, logout, user} = useAuth0()
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
-  const userMenuOpen = Boolean(anchorEl)
+  const [
+    userMenuAnchorElement,
+    setUserMenuAnchorElement,
+  ] = React.useState<null | HTMLElement>(null)
+  const isUserMenuOpen = Boolean(userMenuAnchorElement)
   const theme = useTheme()
   const history = useHistory()
   const isMobile = useMediaQuery(theme.breakpoints.down('xs'))
@@ -45,7 +51,7 @@ export const AppHeader: FC<Props> = ({sideDrawOpen, setSideDrawerOpen}) => {
     loginButton: {
       marginLeft: theme.spacing(1),
     },
-    menuButton: {
+    navigationButton: {
       marginLeft: theme.spacing(1),
     },
     title: {
@@ -55,14 +61,15 @@ export const AppHeader: FC<Props> = ({sideDrawOpen, setSideDrawerOpen}) => {
       padding: theme.spacing(1),
     },
   }))
+
   const classes = useStyles()
 
-  const handleMenu = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget)
+  const handleUserMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setUserMenuAnchorElement(event.currentTarget)
   }
 
-  const handleClose = () => {
-    setAnchorEl(null)
+  const handleUserMenuClose = () => {
+    setUserMenuAnchorElement(null)
   }
 
   const handleNavigate = (pageURL: string) => {
@@ -100,14 +107,14 @@ export const AppHeader: FC<Props> = ({sideDrawOpen, setSideDrawerOpen}) => {
                 aria-label="account of current user"
                 aria-controls="menu-appbar"
                 aria-haspopup="true"
-                onClick={handleMenu}
+                onClick={handleUserMenuOpen}
                 color="inherit"
               >
                 <AccountCircle />
               </IconButton>
               <Menu
                 id="menu-appbar"
-                anchorEl={anchorEl}
+                anchorEl={userMenuAnchorElement}
                 anchorOrigin={{
                   vertical: 'top',
                   horizontal: 'right',
@@ -117,12 +124,16 @@ export const AppHeader: FC<Props> = ({sideDrawOpen, setSideDrawerOpen}) => {
                   vertical: 'top',
                   horizontal: 'right',
                 }}
-                open={userMenuOpen}
-                onClose={handleClose}
+                open={isUserMenuOpen}
+                onClose={handleUserMenuClose}
               >
                 <ListSubheader>{user.nickname}</ListSubheader>
                 <Divider />
-                <MenuItem onClick={handleClose}>My account</MenuItem>
+                <MenuItem
+                  onClick={() => console.log('todo: add link to account page')}
+                >
+                  My account
+                </MenuItem>
                 <MenuItem
                   onClick={() => logout({returnTo: window.location.origin})}
                 >
@@ -139,14 +150,15 @@ export const AppHeader: FC<Props> = ({sideDrawOpen, setSideDrawerOpen}) => {
               Login
             </Button>
           )}
+
           {isMobile ? (
             <IconButton
               edge="start"
-              className={classes.menuButton}
+              className={classes.navigationButton}
               color="inherit"
               aria-label="menu"
               onClick={() => {
-                setSideDrawerOpen(!sideDrawOpen)
+                setIsSideDrawerOpen(!isSideDrawerOpen)
               }}
             >
               <MenuIcon />

--- a/src/layout/layout.tsx
+++ b/src/layout/layout.tsx
@@ -5,17 +5,17 @@ import {AppHeader} from './appHeader'
 import {SideDrawer} from './sideDrawer'
 
 export const Layout: FC = props => {
-  const [sideDrawOpen, setSideDrawerOpen] = useState<boolean>(false)
+  const [isSideDrawerOpen, setIsSideDrawerOpen] = useState<boolean>(false)
   return (
     <>
       <ThemeProvider theme={Theme}>
         <AppHeader
-          sideDrawOpen={sideDrawOpen}
-          setSideDrawerOpen={setSideDrawerOpen}
+          isSideDrawerOpen={isSideDrawerOpen}
+          setIsSideDrawerOpen={setIsSideDrawerOpen}
         />
         <SideDrawer
-          sideDrawOpen={sideDrawOpen}
-          setSideDrawerOpen={setSideDrawerOpen}
+          isSideDrawerOpen={isSideDrawerOpen}
+          setIsSideDrawerOpen={setIsSideDrawerOpen}
         />
         <div>{props.children}</div>
       </ThemeProvider>

--- a/src/layout/layout.tsx
+++ b/src/layout/layout.tsx
@@ -1,13 +1,22 @@
-import {FC} from 'react'
+import {FC, useState} from 'react'
 import {ThemeProvider} from '@material-ui/core'
 import {Theme} from '../theme'
 import {AppHeader} from './appHeader'
+import {SideDrawer} from './sideDrawer'
 
 export const Layout: FC = props => {
+  const [sideDrawOpen, setSideDrawerOpen] = useState<boolean>(false)
   return (
     <>
       <ThemeProvider theme={Theme}>
-        <AppHeader />
+        <AppHeader
+          sideDrawOpen={sideDrawOpen}
+          setSideDrawerOpen={setSideDrawerOpen}
+        />
+        <SideDrawer
+          sideDrawOpen={sideDrawOpen}
+          setSideDrawerOpen={setSideDrawerOpen}
+        />
         <div>{props.children}</div>
       </ThemeProvider>
     </>

--- a/src/layout/sideDrawer.tsx
+++ b/src/layout/sideDrawer.tsx
@@ -1,0 +1,81 @@
+import React, {FC, Dispatch, SetStateAction} from 'react'
+import {useHistory} from 'react-router-dom'
+import {
+  SwipeableDrawer,
+  Button,
+  List,
+  ListItem,
+  makeStyles,
+} from '@material-ui/core'
+import {routes} from '../routes'
+
+interface Props {
+  sideDrawOpen: boolean
+  setSideDrawerOpen: Dispatch<SetStateAction<boolean>>
+}
+
+export const SideDrawer: FC<Props> = ({sideDrawOpen, setSideDrawerOpen}) => {
+  const history = useHistory()
+
+  const useStyles = makeStyles(theme => ({
+    navList: {
+      width: 250,
+    },
+    navLink: {
+      padding: theme.spacing(1),
+    },
+  }))
+  const classes = useStyles()
+
+  const toggleDrawer = (open: boolean) => (
+    event: React.KeyboardEvent | React.MouseEvent,
+  ) => {
+    if (
+      event &&
+      event.type === 'keydown' &&
+      ((event as React.KeyboardEvent).key === 'Tab' ||
+        (event as React.KeyboardEvent).key === 'Shift')
+    ) {
+      return
+    }
+    setSideDrawerOpen(open)
+  }
+
+  const handleNavigate = (pageURL: string) => {
+    setSideDrawerOpen(false)
+    history.push(pageURL)
+  }
+
+  return (
+    <div>
+      <SwipeableDrawer
+        anchor="right"
+        open={sideDrawOpen}
+        onClose={toggleDrawer(false)}
+        onOpen={toggleDrawer(true)}
+      >
+        <List className={classes.navList}>
+          {routes.map(route => {
+            const {linkText, path} = route
+            return (
+              <ListItem
+                button
+                key={linkText}
+                onClick={() => handleNavigate(path)}
+                className={classes.navLink}
+              >
+                <Button
+                  color="inherit"
+                  className={classes.navLink}
+                  onClick={() => handleNavigate(path)}
+                >
+                  {linkText}
+                </Button>
+              </ListItem>
+            )
+          })}
+        </List>
+      </SwipeableDrawer>
+    </div>
+  )
+}

--- a/src/layout/sideDrawer.tsx
+++ b/src/layout/sideDrawer.tsx
@@ -10,39 +10,29 @@ import {
 import {routes} from '../routes'
 
 interface Props {
-  sideDrawOpen: boolean
-  setSideDrawerOpen: Dispatch<SetStateAction<boolean>>
+  isSideDrawerOpen: boolean
+  setIsSideDrawerOpen: Dispatch<SetStateAction<boolean>>
 }
 
-export const SideDrawer: FC<Props> = ({sideDrawOpen, setSideDrawerOpen}) => {
+export const SideDrawer: FC<Props> = ({
+  isSideDrawerOpen,
+  setIsSideDrawerOpen,
+}) => {
   const history = useHistory()
 
   const useStyles = makeStyles(theme => ({
-    navList: {
+    navigationList: {
       width: 250,
     },
-    navLink: {
+    navigationLink: {
       padding: theme.spacing(1),
     },
   }))
+
   const classes = useStyles()
 
-  const toggleDrawer = (open: boolean) => (
-    event: React.KeyboardEvent | React.MouseEvent,
-  ) => {
-    if (
-      event &&
-      event.type === 'keydown' &&
-      ((event as React.KeyboardEvent).key === 'Tab' ||
-        (event as React.KeyboardEvent).key === 'Shift')
-    ) {
-      return
-    }
-    setSideDrawerOpen(open)
-  }
-
   const handleNavigate = (pageURL: string) => {
-    setSideDrawerOpen(false)
+    setIsSideDrawerOpen(false)
     history.push(pageURL)
   }
 
@@ -50,11 +40,11 @@ export const SideDrawer: FC<Props> = ({sideDrawOpen, setSideDrawerOpen}) => {
     <div>
       <SwipeableDrawer
         anchor="right"
-        open={sideDrawOpen}
-        onClose={toggleDrawer(false)}
-        onOpen={toggleDrawer(true)}
+        open={isSideDrawerOpen}
+        onClose={() => setIsSideDrawerOpen(false)}
+        onOpen={() => setIsSideDrawerOpen(true)}
       >
-        <List className={classes.navList}>
+        <List className={classes.navigationList}>
           {routes.map(route => {
             const {linkText, path} = route
             return (
@@ -62,11 +52,11 @@ export const SideDrawer: FC<Props> = ({sideDrawOpen, setSideDrawerOpen}) => {
                 button
                 key={linkText}
                 onClick={() => handleNavigate(path)}
-                className={classes.navLink}
+                className={classes.navigationLink}
               >
                 <Button
                   color="inherit"
-                  className={classes.navLink}
+                  className={classes.navigationLink}
                   onClick={() => handleNavigate(path)}
                 >
                   {linkText}

--- a/src/layout/tom.text
+++ b/src/layout/tom.text
@@ -1,0 +1,1 @@
+test text

--- a/src/layout/tom.text
+++ b/src/layout/tom.text
@@ -1,1 +1,0 @@
-test text

--- a/src/pages/about/about.tsx
+++ b/src/pages/about/about.tsx
@@ -1,0 +1,7 @@
+export const About = () => {
+  return (
+    <div>
+      <h2>About</h2>
+    </div>
+  )
+}

--- a/src/pages/about/index.ts
+++ b/src/pages/about/index.ts
@@ -1,0 +1,1 @@
+export {About} from './about'

--- a/src/pages/contact/contact.tsx
+++ b/src/pages/contact/contact.tsx
@@ -1,0 +1,7 @@
+export const Contact = () => {
+  return (
+    <div>
+      <h2>Contact</h2>
+    </div>
+  )
+}

--- a/src/pages/contact/index.ts
+++ b/src/pages/contact/index.ts
@@ -1,0 +1,1 @@
+export {Contact} from './contact'

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,1 +1,3 @@
 export {Welcome} from './welcome'
+export {About} from './about'
+export {Contact} from './contact'

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -22,10 +22,10 @@ export const AppRouter: React.FC = () => {
           <Switch>
             {routes.map(r => (
               <Route
-                exact={r.extact}
+                key={r.id}
+                exact={r.exact}
                 path={r.path}
                 component={r.component}
-                key={r.path}
               />
             ))}
             <Route path="/editor" component={ProllyEditor} />

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,9 +1,27 @@
-import {Welcome} from './pages'
+import {Welcome, Contact, About} from './pages'
 export const routes = [
   {
     id: 1,
-    extact: true,
+    exact: true,
+    showInHeader: true,
+    linkText: 'Home',
     path: '/',
     component: Welcome,
+  },
+  {
+    id: 2,
+    exact: true,
+    showInHeader: true,
+    linkText: 'About',
+    path: '/about',
+    component: About,
+  },
+  {
+    id: 3,
+    exact: true,
+    showInHeader: true,
+    linkText: 'Contact',
+    path: '/contact',
+    component: Contact,
   },
 ]


### PR DESCRIPTION
Created new pages: pages/about, pages/contact
Added routes to src/routes.tsx
Added linkText attribute to routes objects to display in app header and side drawer
Added showInHeader attribute to routes objects to distinguish routes that might only be showed in footer etc
Added links (pulled from routes array) and a user menu to appHeader
Added side drawer for showing links on mobile

/**
 * Opening the user menu and side drawer generates a warning in the console
 * Apparently this is a known issue when running material ui in strict mode https://github.com/mui-org/material-ui/issues/13394
 * From my reading this will not happen in production and can be resolved by removing strict mode

 */
